### PR TITLE
Update docs for v1.0.2 release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -44,15 +44,15 @@ Splunk Firehose Nozzle for PCF includes the following key features:
   </tr>
   <tr>
     <td>Compatible Ops Manager Version(s)</td>
-    <td>v2.0.x, v2.1.x, v2.2.x, and v2.3.x</td>
+    <td>v2.1.x, v2.2.x, v2.3.x, and v2.4.x</td>
   </tr>
   <tr>
     <td>Compatible Pivotal Application Service (formerly known as Elastic Runtime) version(s)</td>
-    <td>v2.0.x, v2.1.x, v2.2.x, and v2.3.x</td>
+    <td>v2.1.x, v2.2.x, v2.3.x and v2.4.x</td>
   </tr>
     <tr>
        <td>BOSH stemcell version</td>
-       <td>Ubuntu Trusty</td>
+       <td>Ubuntu Xenial</td>
     </tr>
   <tr>
     <td>IaaS Support</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -3,11 +3,6 @@ title: Splunk Firehose Nozzle for PCF
 owner: Partners
 ---
 
-<p class="note warning"><strong> WARNING:</strong>
-This tile requires a Trusty stemcell.
-The end of life date for Ubuntu Trusty is April 2019.
-If a security vulnerability is found on this stemcell after April, it will not be fixed.</p>
-
 This documentation describes the Splunk Nozzle for Pivotal Cloud Foundry (PCF) Firehose.
 Splunk Nozzle integrates with PCF [Loggregator](http://docs.pivotal.io/pivotalcf/1-8/loggregator/index.html)
 and forwards streaming logs and metrics from user apps and system components of Cloud Foundry to Splunk Enterprise.
@@ -40,7 +35,7 @@ Splunk Firehose Nozzle for PCF includes the following key features:
   </tr>
   <tr>
     <td>Release Date</td>
-    <td>May 2, 2018</td>
+    <td>February 27, 2019</td>
   </tr>
   <tr>
     <td>Compatible Ops Manager Version(s)</td>

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -119,6 +119,7 @@ to install Splunk Firehose Nozzle for PCF tile.
       Set to 0 to only populate the cache during startup or restart of the nozzle.
   * **App Limits**: The number of apps for which metadata is gathered when refreshing the app metadata cache (order based on app creation date).
       Set to 0 to remove limit.
-  * **Ignore Missing App**: Do not trigger an app metadata refresh when encountering data from an app without info in the app metadata cache.
+  * **Nozzle Memory**: Nozzle memory in MB.
+
 1. **Resource Config**: Select default options.
 1. **Stemcell**: Ensure the proper stemcell is available.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -4,7 +4,7 @@ owner: Partners
 ---
 
 ### v1.0.2
-**Release Date:** March 1, 2019
+**Release Date:** February 27, 2019
 
 Features:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,6 +3,14 @@ title: Splunk Firehose Nozzle for PCF Release Notes
 owner: Partners
 ---
 
+### v1.0.2
+**Release Date:** March 1, 2019
+
+Features:
+
+* Allows to configure nozzle memory from within the tile.
+
+
 ### v1.0.1
 **Release Date:** May 2, 2018
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -9,6 +9,8 @@ owner: Partners
 Features:
 
 * Allows to configure nozzle memory from within the tile.
+* Includes minor bug fixes.
+* Adds additional logging to report errors bubbled up from annotation.
 
 
 ### v1.0.1


### PR DESCRIPTION
Update docs for tile v1.0.2 release: 
- includes support for PAS 2.4.
- updated stemcell to Ubuntu Xenial.
- updated advanced config section for added config param. 